### PR TITLE
[WIP] Fuzz event logging

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -410,6 +410,18 @@ struct foreign_sync {
 
 };
 
+struct fuzz_event {
+  int64_t timestamp;
+  u64     original_cksum;
+  u64     fuzzed_cksum;
+};
+
+struct fuzz_event_buffer {
+  FILE *            log_file;
+  struct fuzz_event events[16384];
+  u64               size;
+};
+
 typedef struct afl_state {
 
   /* Position of this state in the global states list */
@@ -758,6 +770,8 @@ typedef struct afl_state {
   FILE *introspection_file;
   u32   bitsmap_size;
 #endif
+
+  struct fuzz_event_buffer event_buffer;
 
 } afl_state_t;
 

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -411,7 +411,7 @@ struct foreign_sync {
 };
 
 struct fuzz_event {
-  int64_t timestamp;
+  int64_t dur;
   u64     original_cksum;
   u64     fuzzed_cksum;
 };
@@ -420,6 +420,7 @@ struct fuzz_event_buffer {
   FILE *            log_file;
   struct fuzz_event events[16384];
   u64               size;
+  int64_t           started_at;
 };
 
 typedef struct afl_state {

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -27,6 +27,7 @@
 #include "afl-fuzz.h"
 #include <sys/time.h>
 #include <signal.h>
+#include <time.h>
 #include <limits.h>
 #if !defined NAME_MAX
   #define NAME_MAX _XOPEN_NAME_MAX
@@ -920,6 +921,49 @@ common_fuzz_stuff(afl_state_t *afl, u8 *out_buf, u32 len) {
   write_to_testcase(afl, out_buf, len);
 
   fault = fuzz_run_target(afl, &afl->fsrv, afl->fsrv.exec_tmout);
+
+  int write_event_log = 1;
+  if (write_event_log) {
+    struct fuzz_event_buffer *buffer = &afl->event_buffer;
+    u64                       buf_size = buffer->size;
+    u64                       buf_max_len = 16384;
+    if (buf_max_len <= buf_size) {
+      // TODO(wuestholz): Trigger this before AFL terminates.
+      FILE *f = buffer->log_file;
+      if (!f) {
+        f = fopen(alloc_printf("%s/fuzz_event_log.csv", afl->out_dir), "w");
+        if (!f) { PFATAL("Unable to create 'fuzz_event_log.csv'"); }
+        buffer->log_file = f;
+      }
+
+      for (u64 i = 0; i < buf_max_len; i++) {
+        struct fuzz_event event = buffer->events[i];
+        fprintf(f, "%ld,%llx,%llx\n", event.timestamp, event.original_cksum,
+                event.fuzzed_cksum);
+      }
+      fflush(f);
+      // fclose(f);
+
+      buf_size = 0;
+      buffer->size = buf_size;
+    }
+
+    u64 cur_cksum = afl->queue_cur->exec_cksum;
+    if (cur_cksum) {
+      struct timespec tms;
+      if (clock_gettime(CLOCK_REALTIME, &tms)) { PFATAL("Unable to get time"); }
+      int64_t ms = tms.tv_sec * 1000000;
+      ms += tms.tv_nsec / 1000;
+      if (tms.tv_nsec % 1000 >= 500) { ++ms; }
+      struct fuzz_event new_event;
+      new_event.timestamp = ms;
+      new_event.original_cksum = afl->queue_cur->exec_cksum;
+      new_event.fuzzed_cksum =
+          hash64(afl->fsrv.trace_bits, afl->fsrv.map_size, HASH_CONST);
+      buffer->events[buf_size] = new_event;
+      buffer->size++;
+    }
+  }
 
   if (afl->stop_soon) { return 1; }
 

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -938,8 +938,10 @@ common_fuzz_stuff(afl_state_t *afl, u8 *out_buf, u32 len) {
 
       for (u64 i = 0; i < buf_max_len; i++) {
         struct fuzz_event event = buffer->events[i];
-        fprintf(f, "%ld,%llx,%llx\n", event.timestamp, event.original_cksum,
-                event.fuzzed_cksum);
+        // We reduce the size of the checksums to save space.
+        u32 oc32 = event.original_cksum - (event.original_cksum >> ((u64)32));
+        u32 fc32 = event.fuzzed_cksum - (event.fuzzed_cksum >> ((u64)32));
+        fprintf(f, "%ld,%x,%x\n", event.dur, oc32, fc32);
       }
       fflush(f);
       // fclose(f);
@@ -950,13 +952,15 @@ common_fuzz_stuff(afl_state_t *afl, u8 *out_buf, u32 len) {
 
     u64 cur_cksum = afl->queue_cur->exec_cksum;
     if (cur_cksum) {
-      struct timespec tms;
-      if (clock_gettime(CLOCK_REALTIME, &tms)) { PFATAL("Unable to get time"); }
-      int64_t ms = tms.tv_sec * 1000000;
-      ms += tms.tv_nsec / 1000;
-      if (tms.tv_nsec % 1000 >= 500) { ++ms; }
+      struct timespec time_now;
+      if (clock_gettime(CLOCK_REALTIME, &time_now)) {
+        PFATAL("Unable to get time");
+      }
+      if (buffer->started_at < 1 && buf_size < 1) {
+        buffer->started_at = time_now.tv_sec;
+      }
       struct fuzz_event new_event;
-      new_event.timestamp = ms;
+      new_event.dur = time_now.tv_sec - buffer->started_at;
       new_event.original_cksum = afl->queue_cur->exec_cksum;
       new_event.fuzzed_cksum =
           hash64(afl->fsrv.trace_bits, afl->fsrv.map_size, HASH_CONST);


### PR DESCRIPTION
This adds logging for fuzz events. It keeps track of the following for each fuzzed input that is executed:
- the time (in secs) since the start of the campaign
- the path ID (i.e., checksum) of the original (i.e., seed) input that was fuzzed/mutated
- the path ID of the resulting fuzzed input

The log is written to a CSV file (fuzz_event_log.csv) with one line per event. The format is the following:

```
<time in secs>,<original path ID>,<fuzzed path ID>
```

Note that we don't log the full 64-bit IDs, but a shorter 32-bit ID. This is an attempt to save space since the log file can become quite large for long-running campaigns.